### PR TITLE
fix: withdraw root mismatch when restarting

### DIFF
--- a/internal/controller/contract.go
+++ b/internal/controller/contract.go
@@ -208,7 +208,7 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, originalStart, end, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
 			if checkErr != nil {
 				c.contractControllerCheckWithdrawRootFailureTotal.WithLabelValues(types.Layer2.String()).Inc()
-				log.Error("check withdraw roots failed", "layer", types.Layer2, "end", end, "error", checkErr)
+				log.Error("check withdraw roots failed", "layer", types.Layer2, "start", originalStart, "end", end, "error", checkErr)
 				continue
 			}
 		}

--- a/internal/controller/contract.go
+++ b/internal/controller/contract.go
@@ -205,7 +205,7 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 		var lastMessage *orm.MessageMatch
 		if layer == types.Layer2 {
 			var checkErr error
-			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, end, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
+			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, originalStart, end, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
 			if checkErr != nil {
 				c.contractControllerCheckWithdrawRootFailureTotal.WithLabelValues(types.Layer2.String()).Inc()
 				log.Error("check withdraw roots failed", "layer", types.Layer2, "end", end, "error", checkErr)

--- a/internal/logic/checker/checker.go
+++ b/internal/logic/checker/checker.go
@@ -70,7 +70,7 @@ func (c *Checker) CheckL2WithdrawRoots(ctx context.Context, startBlockNumber, en
 	}
 	// recover latest withdraw trie.
 	withdrawTrie := msgproof.NewWithdrawTrie()
-	msg, err := c.messageMatchOrm.GetLargestMessageNonceL2MessageMatch(ctx)
+	msg, err := c.messageMatchOrm.GetLatestValidL2SentMessageMatch(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get largest message nonce l2 message match failed, err: %w", err)
 	}
@@ -125,6 +125,8 @@ func (c *Checker) CheckL2WithdrawRoots(ctx context.Context, startBlockNumber, en
 				MessageProof:          proofs[numEvents-1],
 				WithdrawRootStatus:    int(types.WithdrawRootStatusTypeValid),
 				MessageProofUpdatedAt: utils.NowUTC(),
+				NextMessageNonce:      withdrawTrie.NextMessageNonce,
+				L2BlockNumber:         blockNum,
 			}
 		}
 	}

--- a/internal/logic/checker/checker.go
+++ b/internal/logic/checker/checker.go
@@ -63,16 +63,23 @@ func (c *Checker) GatewayCheck(ctx context.Context, eventCategory types.EventCat
 }
 
 // CheckL2WithdrawRoots checks the L2 withdraw roots.
-func (c *Checker) CheckL2WithdrawRoots(ctx context.Context, startBlockNumber, endBlockNumber uint64, client *rpc.Client, messageQueueAddr common.Address) (*orm.MessageMatch, error) {
-	log.Info("checking l2 withdraw roots", "start", startBlockNumber, "end", endBlockNumber)
+func (c *Checker) CheckL2WithdrawRoots(ctx context.Context, endBlockNumber uint64, client *rpc.Client, messageQueueAddr common.Address) (*orm.MessageMatch, error) {
 	// recover latest withdraw trie.
 	withdrawTrie := msgproof.NewWithdrawTrie()
 	msg, err := c.messageMatchOrm.GetLargestMessageNonceL2MessageMatch(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get largest message nonce l2 message match failed, err: %w", err)
 	}
+	var startBlockNumber uint64
 	if msg != nil {
 		withdrawTrie.Initialize(msg.NextMessageNonce-1, common.HexToHash(msg.MessageHash), msg.MessageProof)
+		startBlockNumber = msg.L2BlockNumber + 1
+	} else {
+		startBlockNumber = 1
+	}
+	log.Info("checking l2 withdraw roots", "start", startBlockNumber, "end", endBlockNumber)
+	if startBlockNumber > endBlockNumber {
+		return nil, nil
 	}
 
 	l2SentMessages, err := c.messageMatchOrm.GetL2SentMessagesInBlockRange(ctx, startBlockNumber, endBlockNumber)

--- a/internal/orm/message_match.go
+++ b/internal/orm/message_match.go
@@ -325,7 +325,7 @@ func (m *MessageMatch) UpdateMsgProofAndStatus(ctx context.Context, message *Mes
 	}
 	db = db.WithContext(ctx)
 	db = db.Model(&MessageMatch{})
-	db = db.Where("message_hash <= ?", message.MessageHash)
+	db = db.Where("message_hash = ?", message.MessageHash)
 
 	updateFields := map[string]interface{}{
 		"message_proof":        message.MessageProof,

--- a/internal/orm/message_match.go
+++ b/internal/orm/message_match.go
@@ -126,8 +126,10 @@ func (m *MessageMatch) GetLatestBlockValidMessageMatch(ctx context.Context, laye
 	switch layer {
 	case types.Layer1:
 		db = db.Where("l1_block_status = ?", types.BlockStatusTypeValid)
+		db = db.Order("l1_block_number desc")
 	case types.Layer2:
 		db = db.Where("l2_block_status = ?", types.BlockStatusTypeValid)
+		db = db.Order("l2_block_number desc")
 	}
 	err := db.Last(&message).Error
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -182,8 +184,8 @@ func (m *MessageMatch) GetLatestValidETHBalanceMessageMatch(ctx context.Context,
 	return &message, nil
 }
 
-// GetLargestMessageNonceL2MessageMatch fetches the message match record with the maximum MessageNonce.
-func (m *MessageMatch) GetLargestMessageNonceL2MessageMatch(ctx context.Context) (*MessageMatch, error) {
+// GetLatestValidL2SentMessageMatch fetches the valid l2 sent message with the largest message nonce.
+func (m *MessageMatch) GetLatestValidL2SentMessageMatch(ctx context.Context) (*MessageMatch, error) {
 	var message MessageMatch
 	db := m.db.WithContext(ctx)
 	db = db.Where("withdraw_root_status = ?", types.WithdrawRootStatusTypeValid)
@@ -194,8 +196,8 @@ func (m *MessageMatch) GetLargestMessageNonceL2MessageMatch(ctx context.Context)
 		return nil, nil
 	}
 	if err != nil {
-		log.Warn("GetLargestMessageNonceL2MessageMatch failed", "error", err)
-		return nil, fmt.Errorf("GetLargestMessageNonceL2MessageMatch failed, err:%w", err)
+		log.Warn("GetLatestValidL2SentMessageMatch failed", "error", err)
+		return nil, fmt.Errorf("GetLatestValidL2SentMessageMatch failed, err:%w", err)
 	}
 	return &message, nil
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

If the program exits after updating the withdraw root status and before updating the block status, it will result in a withdraw root check mismatch. This PR moves the updates into a DB transaction.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
