### PR TITLE
feat: add reentrancy cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-resty/resty/v2 v2.10.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.19
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pressly/goose/v3 v3.15.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/scroll-tech/go-ethereum v1.10.14-0.20231122064408-9f143b47b25b

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.0.3-0.20180606204148-bd9c31933947/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=

--- a/internal/controller/contract.go
+++ b/internal/controller/contract.go
@@ -491,7 +491,7 @@ func (c *ContractController) reentrancyWatchStart() {
 		}
 
 		count := c.reentrancyWatchCache.ItemCount()
-		c.reentrancyWatchCacheSize.Inc()
+		c.reentrancyWatchCacheSize.Set(float64(count))
 		if count <= 0 {
 			continue
 		}

--- a/internal/controller/cross_chain.go
+++ b/internal/controller/cross_chain.go
@@ -17,8 +17,9 @@ import (
 
 // CrossChainController is a struct that contains a reference to the Logic object.
 type CrossChainController struct {
-	crossChainLogic *crosschain.LogicCrossChain
-	stopTimeoutChan chan struct{}
+	crossChainLogic      *crosschain.LogicCrossChain
+	stopL1CrossChainChan chan struct{}
+	stopL2CrossChainChan chan struct{}
 
 	crossChainControllerRunningTotal *prometheus.CounterVec
 }
@@ -28,8 +29,9 @@ func NewCrossChainController(cfg *config.Config, db *gorm.DB, l1Client, l2Client
 	l1MessengerAddr := cfg.L1Config.L1Contracts.ScrollMessenger
 	l2MessengerAddr := cfg.L2Config.L2Contracts.ScrollMessenger
 	return &CrossChainController{
-		stopTimeoutChan: make(chan struct{}),
-		crossChainLogic: crosschain.NewCrossChainLogic(db, l1Client, l2Client, l1MessengerAddr, l2MessengerAddr),
+		stopL1CrossChainChan: make(chan struct{}),
+		stopL2CrossChainChan: make(chan struct{}),
+		crossChainLogic:      crosschain.NewCrossChainLogic(db, l1Client, l2Client, l1MessengerAddr, l2MessengerAddr),
 		crossChainControllerRunningTotal: promauto.With(prometheus.DefaultRegisterer).NewCounterVec(prometheus.CounterOpts{
 			Name: "cross_chain_check_controller_running_total",
 			Help: "The total number of cross chain controller running.",
@@ -46,7 +48,8 @@ func (c *CrossChainController) Watch(ctx context.Context) {
 
 // Stop all the cross chain controller
 func (c *CrossChainController) Stop() {
-	c.stopTimeoutChan <- struct{}{}
+	c.stopL1CrossChainChan <- struct{}{}
+	c.stopL2CrossChainChan <- struct{}{}
 }
 
 func (c *CrossChainController) watcherStart(ctx context.Context, layer types.LayerType) {
@@ -56,11 +59,14 @@ func (c *CrossChainController) watcherStart(ctx context.Context, layer types.Lay
 		select {
 		case <-ctx.Done():
 			if ctx.Err() != nil {
-				log.Error("CrossChainController proposer canceled with error", "layer", layer.String(), "error", ctx.Err())
+				log.Error("CrossChainController canceled with error", "layer", layer.String(), "error", ctx.Err())
 			}
 			return
-		case <-c.stopTimeoutChan:
-			log.Info("CrossChainController proposer the run loop exit", "layer", layer.String())
+		case <-c.stopL1CrossChainChan:
+			log.Info("CrossChainController l1 the run loop exit", "layer", layer.String())
+			return
+		case <-c.stopL2CrossChainChan:
+			log.Info("CrossChainController l2 the run loop exit", "layer", layer.String())
 			return
 		default:
 		}
@@ -71,6 +77,6 @@ func (c *CrossChainController) watcherStart(ctx context.Context, layer types.Lay
 		c.crossChainLogic.CheckETHBalance(ctx, layer)
 
 		// To prevent frequent database access, obtaining empty values.
-		time.Sleep(60 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 }

--- a/internal/orm/migrate/migrate.go
+++ b/internal/orm/migrate/migrate.go
@@ -18,7 +18,7 @@ const MigrationsDir string = "migrations"
 func init() {
 	goose.SetBaseFS(embedMigrations)
 	goose.SetSequential(true)
-	goose.SetTableName("chain_monitor_migrations")
+	goose.SetTableName("chain_monitor_v2_migrations")
 
 	verbose, _ := strconv.ParseBool(os.Getenv("LOG_SQL_MIGRATIONS"))
 	goose.SetVerbose(verbose)


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

sometimes l1Watch and l2Watch maybe filter logs failed for the network jitter.
this will leave out some events. So ReentrancyWatch is a mechanism to watch and filter the failed event logs again.
base case: if the cache have reentrancy data when program exit, this case can't guarantee.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
