### PR TITLE
fix: only change the start block when successful

### DIFF
--- a/internal/controller/contract.go
+++ b/internal/controller/contract.go
@@ -211,10 +211,10 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 		var lastMessage *orm.MessageMatch
 		if layer == types.Layer2 {
 			var checkErr error
-			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, loopStart, loopEnd, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
+			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, start, loopEnd, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
 			if checkErr != nil {
 				c.contractControllerCheckWithdrawRootFailureTotal.WithLabelValues(types.Layer2.String()).Inc()
-				log.Error("check withdraw roots failed", "layer", types.Layer2, "start", loopStart, "end", loopEnd, "error", checkErr)
+				log.Error("check withdraw roots failed", "layer", types.Layer2, "start", start, "end", loopEnd, "error", checkErr)
 				continue
 			}
 		}
@@ -227,13 +227,13 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 				}
 			}
 
-			if err = c.messageMatchOrm.UpdateBlockStatus(ctx, layer, loopStart, loopEnd, tx); err != nil {
+			if err = c.messageMatchOrm.UpdateBlockStatus(ctx, layer, start, loopEnd, tx); err != nil {
 				return fmt.Errorf("update block status failed, err: %w", err)
 			}
 			return nil
 		})
 		if err != nil {
-			log.Error("update db status after check failed", "layer", layer, "from", loopStart, "end", loopEnd, "err", err)
+			log.Error("update db status after check failed", "layer", layer, "from", start, "end", loopEnd, "err", err)
 			continue
 		}
 

--- a/internal/controller/contract.go
+++ b/internal/controller/contract.go
@@ -166,13 +166,13 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 		}
 
 		var eg errgroup.Group
-		tmpStart := start
-		var end uint64
+		loopStart := start
+		var loopEnd uint64
 		for i := 0; i < concurrency; i++ {
-			if start > confirmationNumber {
-				log.Info("Watcher start block number > ConfirmationNumber",
+			if loopStart > confirmationNumber {
+				log.Info("Watcher loop start block number > ConfirmationNumber",
 					"layer", layer.String(),
-					"startBlockNumber", start,
+					"startBlockNumber", loopStart,
 					"confirmationNumber", confirmationNumber,
 					"err", err,
 				)
@@ -181,14 +181,14 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 			}
 
 			// 3. get the max fetch number
-			end = tmpStart + maxBlockFetchSize
-			if start+maxBlockFetchSize > confirmationNumber {
-				end = confirmationNumber
+			loopEnd = loopStart + maxBlockFetchSize
+			if loopStart+maxBlockFetchSize > confirmationNumber {
+				loopEnd = confirmationNumber
 			}
 
-			currentStart := tmpStart
-			currentEnd := end
-			tmpStart = end + 1
+			currentStart := loopStart
+			currentEnd := loopEnd
+			loopStart = loopEnd + 1
 
 			c.contractControllerBlockNumber.WithLabelValues(layer.String()).Set(float64(currentEnd))
 
@@ -211,10 +211,10 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 		var lastMessage *orm.MessageMatch
 		if layer == types.Layer2 {
 			var checkErr error
-			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, start, end, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
+			lastMessage, checkErr = c.checker.CheckL2WithdrawRoots(ctx, loopStart, loopEnd, c.l2Client, c.conf.L2Config.L2Contracts.MessageQueue)
 			if checkErr != nil {
 				c.contractControllerCheckWithdrawRootFailureTotal.WithLabelValues(types.Layer2.String()).Inc()
-				log.Error("check withdraw roots failed", "layer", types.Layer2, "start", start, "end", end, "error", checkErr)
+				log.Error("check withdraw roots failed", "layer", types.Layer2, "start", loopStart, "end", loopEnd, "error", checkErr)
 				continue
 			}
 		}
@@ -227,18 +227,18 @@ func (c *ContractController) watcherStart(ctx context.Context, client *ethclient
 				}
 			}
 
-			if err = c.messageMatchOrm.UpdateBlockStatus(ctx, layer, start, end, tx); err != nil {
+			if err = c.messageMatchOrm.UpdateBlockStatus(ctx, layer, loopStart, loopEnd, tx); err != nil {
 				return fmt.Errorf("update block status failed, err: %w", err)
 			}
 			return nil
 		})
 		if err != nil {
-			log.Error("update db status after check failed", "layer", layer, "from", start, "end", end, "err", err)
+			log.Error("update db status after check failed", "layer", layer, "from", loopStart, "end", loopEnd, "err", err)
 			continue
 		}
 
 		// Update start after all handlings are successful.
-		start = end + 1
+		start = loopEnd + 1
 	}
 }
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

Only change the start block when successful, preventing missing fetching events, which is very hard to detect and identify the issue.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
