### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/internal/logic/message_match/message.go
+++ b/internal/logic/message_match/message.go
@@ -2,6 +2,7 @@ package messagematch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/scroll-tech/go-ethereum/log"
@@ -154,7 +155,7 @@ func (t *LogicMessageMatch) InsertOrUpdateMessageMatches(ctx context.Context, la
 
 			if effectRow == 0 {
 				slack.Notify(slack.MrkDwnMessengerMessageMatchDuplicated(layer, message))
-				return fmt.Errorf("messenger event orm insert duplicated")
+				return errors.New("messenger event orm insert duplicated")
 			}
 			effectRows += effectRow
 		}
@@ -174,7 +175,7 @@ func (t *LogicMessageMatch) InsertOrUpdateMessageMatches(ctx context.Context, la
 
 			if effectRow == 0 {
 				slack.Notify(slack.MrkDwnGatewayMessageMatchDuplicated(layer, message))
-				return fmt.Errorf("gateway event orm insert duplicated")
+				return errors.New("gateway event orm insert duplicated")
 			}
 			effectRows += effectRow
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -108,7 +109,7 @@ func GetL2WithdrawRootsForBlocks(ctx context.Context, cli *rpc.Client, queueAddr
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func UnpackLog(c *abi.ABI, out interface{}, event string, log types.Log) error {
 	if log.Topics[0] != c.Events[event].ID {
-		return fmt.Errorf("event signature mismatch")
+		return errors.New("event signature mismatch")
 	}
 	if len(log.Data) > 0 {
 		if err := c.UnpackIntoInterface(out, event, log.Data); err != nil {


### PR DESCRIPTION
Standardized error handling across multiple components by replacing `fmt.Errorf` with `errors.New`.